### PR TITLE
fix(posix): Add config/grid path to gridDirInput using path.join

### DIFF
--- a/src/write-all-covers.js
+++ b/src/write-all-covers.js
@@ -124,8 +124,9 @@ function writeCovers() {
 function setInputs() {
   console.log(gridDir);
   var gridDirInput = (
-    document.getElementById('grid-dir').value.replace(/\\/g, '\\') + '\\config\\grid\\'
+    document.getElementById('grid-dir').value.replace(/\\/g, '\\')
   ).trim();
+  gridDirInput = path.join(gridDirInput, 'config', 'grid', '/');
   var STEAMIDInput = document.getElementById('steam-ID').value.trim();
   var STEAMAPIInput = document.getElementById('steam-APIKEY').value.trim();
   var error = false;


### PR DESCRIPTION
Minor change to add path to grid folder using path.join to allow macOS and Linux users to use the application.